### PR TITLE
fix: remove stale proc-sys-kernel-random plug

### DIFF
--- a/latest/snap/snapcraft.yaml
+++ b/latest/snap/snapcraft.yaml
@@ -21,13 +21,6 @@ plugs:
     interface: system-files
     read:
       - /etc/script-exporter.yaml
-  proc-sys-kernel-random:
-    interface: system-files
-    read:
-      - /proc/sys/kernel/random/write_wakeup_threshold
-      - /proc/sys/kernel/random/read_wakeup_threshold
-      - /proc/sys/kernel/random/poolsize
-      - /proc/sys/kernel/random/urandom_min_reseed_secs
 apps:
   script-exporter:
     daemon: simple
@@ -43,7 +36,6 @@ apps:
       - system-observe
       - log-observe
       - etc-script-exporter
-      - proc-sys-kernel-random
 parts:
   wrapper:
     plugin: dump


### PR DESCRIPTION
Removes the custom proc-sys-kernel-random plug flagged during snap store review.

- poolsize, urandom_min_reseed_secs, write_wakeup_threshold are already granted by system-observe, so the custom plug was redundant for these.
- read_wakeup_threshold was removed from the kernel in 2019 (torvalds/linux@c95ea0c) and no longer exists on supported systems, so granting access to it has no effect.